### PR TITLE
存在しないメソッドの参照

### DIFF
--- a/lib/diva/type.rb
+++ b/lib/diva/type.rb
@@ -166,7 +166,7 @@ module Diva::Type
     end
 
     def to_s
-      "Array of #{type.to_s}"
+      "Array of #{@type.to_s}"
     end
   end
 
@@ -185,7 +185,7 @@ module Diva::Type
     end
 
     def to_s
-      "#{type.to_s}|nil"
+      "#{@type.to_s}|nil"
     end
   end
 


### PR DESCRIPTION
Diva::Model.fields を Kernel#p に渡したらクラッシュしたので確認してみたところ、どうやらインスタンス変数の@が付いていなかったようです。
